### PR TITLE
Add feature to log boot ID

### DIFF
--- a/man/sysklogd.8
+++ b/man/sysklogd.8
@@ -115,6 +115,11 @@ within the syslogd.c source file.  An example for a chroot() daemon is
 described by the people from OpenBSD at
 <http://www.guides.sk/psionic/dns/>.
 .TP
+.BI "\-b"
+Include the last 4 characters of the kernel boot ID from
+.B /proc/sys/kernel/random/boot_id
+in the log messages.  This is useful for embedded systems.
+.TP
 .B "\-c"
 Disable the repeating line compression that normally suppresses the
 repeated lines and logs a message such as 'last message repeated 124

--- a/src/syslogd/arguments.c
+++ b/src/syslogd/arguments.c
@@ -125,7 +125,7 @@ void parse_arguments(int argc, char **argv, struct globals *g)
 	g->family = PF_INET; /* protocol family (IPv4 only) */
 #endif
 
-	while ((c = getopt(argc, argv, "46Aa:cdhf:i:j:l:m:np:P:rs:u:v")) != EOF) {
+	while ((c = getopt(argc, argv, "46Aa:bcdhf:i:j:l:m:np:P:rs:u:v")) != EOF) {
 		switch (c) {
 			case '4':
 				g->family = PF_INET;
@@ -140,6 +140,9 @@ void parse_arguments(int argc, char **argv, struct globals *g)
 				break;
 			case 'a':
 				set_input(INPUT_UNIX, optarg, -1);
+				break;
+			case 'b':
+				g->options |= OPT_BOOT_ID;
 				break;
 			case 'c': /* don't compress repeated messages */
 				g->options &= ~OPT_COMPRESS;

--- a/src/syslogd/syslogd.h
+++ b/src/syslogd/syslogd.h
@@ -37,6 +37,7 @@ enum option_flag {
 	OPT_NET_HOPS      = (1 << 3), /* can we bounce syslog messages through an
 	                               * intermediate host. */
 	OPT_ACCEPT_REMOTE = (1 << 4), /* receive messages that come via UDP */
+	OPT_BOOT_ID       = (1 << 5)  /* include boot ID in messages */
 };
 
 struct globals {
@@ -52,6 +53,7 @@ struct globals {
 	const char *devlog;
 	const char *config_file;
 	const char *funix_dir;
+	char boot_id[5];            /* Last 4 of the kernel boot ID */
 };
 
 enum log_format_type {


### PR DESCRIPTION
This feature logs the last 4 characters of the boot ID.  This is useful for embedded systems without an RTC, because they may log similar-looking messages across reboots without any indication that a reboot occurred.